### PR TITLE
typo validateInResponseTo

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ function strategy (options, verify) {
     options.disableRequestedAuthnContext = true;
   }
 
-  if (options.validatedInResponseTo === undefined) {
+  if (options.validateInResponseTo === undefined) {
     options.validateInResponseTo = true;
   }
 


### PR DESCRIPTION
Typo in options defaults. Should be `validateInResponseTo` according to https://www.npmjs.com/package/passport-saml